### PR TITLE
fix: Escape markdown in PR description and title for safe storage

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -26,17 +26,17 @@ jobs:
       - name: Get PR description
         id: pr_data
         run: |
-          # Store PR data in files instead of directly in env vars to avoid shell interpretation
-          echo '${{ github.event.pull_request.body }}' > pr_description.txt
-          echo '${{ github.event.pull_request.title }}' > pr_title.txt
+          # Store PR data in files with escaped markdown
+          echo '${{ github.event.pull_request.body }}' | sed 's/```/\\`\\`\\`/g' > pr_description.txt
+          echo '${{ github.event.pull_request.title }}' | sed 's/```/\\`\\`\\`/g' > pr_title.txt
 
           # Read the files and set multiline env vars safely
           echo "PR_DESCRIPTION<<EOF" >> $GITHUB_ENV
           cat pr_description.txt >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-          # For single line title, we can use quotes
-          PR_TITLE=$(cat pr_title.txt)
+          # For single line title, escape any remaining special characters
+          PR_TITLE=$(cat pr_title.txt | sed 's/[_*~`]/\\&/g')
           echo "PR_TITLE='$PR_TITLE'" >> $GITHUB_ENV
 
       - name: Get commit messages


### PR DESCRIPTION
## Description by Korbit AI

### What change is being made?

Escape markdown special characters in pull request descriptions and titles for safe storage in GitHub Actions workflow.

### Why are these changes being made?

This change ensures that markdown syntax within pull request descriptions and titles does not interfere with the storage and subsequent usage of this data in GitHub Actions. By escaping special characters such as backticks and reserved markdown characters, the risk of misinterpretation and errors in workflow processing is reduced, promoting data integrity and safe execution.
